### PR TITLE
Add video_enabled status

### DIFF
--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -1,5 +1,5 @@
 class Conference < ApplicationRecord
-  enum status: { registered: 0, opened: 1, closed: 2, archived: 3 }
+  enum status: { registered: 0, opened: 1, closed: 2, archived: 3, video_enabled: 4 }
   enum speaker_entry: { speaker_entry_disabled: 0, speaker_entry_enabled: 1 }
   enum attendee_entry: { attendee_entry_disabled: 0, attendee_entry_enabled: 1 }
   enum show_timetable: { show_timetable_disabled: 0, show_timetable_enabled: 1 }

--- a/app/views/layouts/_event_header.html.erb
+++ b/app/views/layouts/_event_header.html.erb
@@ -14,13 +14,13 @@
     <div class="collapse navbar-collapse" id="navbarResponsive">
       <ul class="navbar-nav ml-auto my-2 my-lg-0 align-items-center">
         <% unless event_name.nil? %>
-          <% if @conference && (@conference.registered? || @conference.opened?) && @conference.attendee_entry_enabled? %>
+          <% if @conference && (@conference.registered? || @conference.opened? || @conference.video_enabled? ) && @conference.attendee_entry_enabled? %>
             <% if logged_in? && @profile.present? %>
               <li class="nav-item"><%= link_to "ダッシュボード", dashboard_path, class: "nav-link js-scroll-trigger" %></li>
             <% end %>
           <% end %>
           <% unless controller_name == "profiles" && (action_name == "new" || action_name == "create") %>
-            <% if @conference.present? && @conference.opened? %>
+            <% if @conference.present? && (@conference.opened? || @conference.video_enabled?) %>
               <li class="nav-item"><%= link_to "Booths", booths_path, class: "nav-link js-scroll-trigger" %></li>
             <% end %>
 

--- a/app/views/talks/partial_show/_col_main_pane.html.erb
+++ b/app/views/talks/partial_show/_col_main_pane.html.erb
@@ -12,7 +12,7 @@
         <%= render 'talks/partial_show/col_talk_category_block', talk: talk %>
       </div>
 
-      <% if (conference.closed? && @current_user) || (conference.opened? && @current_user) || conference.archived? %>
+      <% if (conference.closed? && @current_user) || (conference.opened? && @current_user) || (conference.video_enabled? && @current_user) ||  conference.archived? %>
         <%= render 'talks/partial_show/talk_video_block', talk: talk %>
       <% end %>
 

--- a/app/views/talks/partial_show/_talk_video_block.html.erb
+++ b/app/views/talks/partial_show/_talk_video_block.html.erb
@@ -1,4 +1,4 @@
-<% if talk.video_published && talk.video.present? && talk.archived? %>
+<% if talk.video.present? %>
   <div class="mb-2">
     <div style="padding:56.25% 0 0 0;position:relative;">
       <iframe src="https://player.vimeo.com/video/<%= talk.video.video_id %>" id="video" frameborder="0" style="position:absolute;top:0;left:0;width:100%;height:100%;" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>

--- a/app/views/talks/show.html.erb
+++ b/app/views/talks/show.html.erb
@@ -12,12 +12,8 @@
 <div class="container">
   <div class="row my-3">
 
-    <div class="col-12 col-lg-8 main-pane">
+    <div class="col-12 main-pane">
       <%= render 'talks/partial_show/col_main_pane', talk: @talk, conference: @conference %>
-    </div>
-
-    <div class="col-12 col-lg-4 sub-pane mt-3 mt-lg-0">
-      <%= render 'talks/partial_show/col_sub_pane', talk: @talk %>
     </div>
 
   </div>

--- a/spec/factories/conferences.rb
+++ b/spec/factories/conferences.rb
@@ -72,6 +72,25 @@ Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliqu
 Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
 Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum." }
   end
+
+  factory :cndt2020_video_enabled, class: Conference do
+    id { 1 }
+    name { 'CloudNative Days Tokyo 2020'}
+    abbr { 'cndt2020' }
+    theme { 'これはTestEventAutumn2020のテーマです' }
+    copyright { '© Test Event Autumn 2020 Committee' }
+    privacy_policy { 'This is Privacy Policy' }
+    privacy_policy_for_speaker { 'This is Privacy Policy for speaker' }
+    status { 4 }
+    speaker_entry { 1 }
+    attendee_entry { 1 }
+    show_timetable { 1 }
+    about { "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum." }
+  end
+
   factory :cndo2021, class: Conference do
     id { 2 }
     name { 'CloudNative Days Online 2021'}

--- a/spec/requests/talks_spec.rb
+++ b/spec/requests/talks_spec.rb
@@ -37,12 +37,6 @@ describe TalksController, type: :request do
           expect(response).to be_successful
           expect(response.body).not_to include "player.vimeo.com"
         end
-
-        it "doesn't includes slido iframe" do
-          get '/cndt2020/talks/1'
-          expect(response).to be_successful
-          expect(response.body).not_to include "sli.do"
-        end
       end
 
       context 'site opened' do
@@ -51,28 +45,10 @@ describe TalksController, type: :request do
           create(:cndt2020_opened)
         end
 
-        context 'talk is archived' do
-          before do
-            allow_any_instance_of(Talk).to receive(:archived?).and_return(true)
-          end
-
-          it "doesn't includes vimeo iframe" do
-            get '/cndt2020/talks/1'
-            expect(response).to be_successful
-            expect(response.body).not_to include "player.vimeo.com"
-          end
-        end
-
-        context 'talk is not archived' do
-          before do
-            allow_any_instance_of(Talk).to receive(:archived?).and_return(false)
-          end
-
-          it "doesn't includes vimeo iframe" do
-            get '/cndt2020/talks/1'
-            expect(response).to be_successful
-            expect(response.body).not_to include "player.vimeo.com"
-          end
+        it "doesn't includes vimeo iframe" do
+          get '/cndt2020/talks/1'
+          expect(response).to be_successful
+          expect(response.body).not_to include "player.vimeo.com"
         end
       end
 
@@ -82,28 +58,10 @@ describe TalksController, type: :request do
           create(:cndt2020_closed)
         end
 
-        describe 'talk is archived' do
-          before do
-            allow_any_instance_of(Talk).to receive(:archived?).and_return(true)
-          end
-
-          it "includes vimeo iframe" do
-            get '/cndt2020/talks/1'
-            expect(response).to be_successful
-            expect(response.body).to_not include "player.vimeo.com"
-          end
-        end
-
-        context 'talk is not archived' do
-          before do
-            allow_any_instance_of(Talk).to receive(:archived?).and_return(false)
-          end
-
-          it "doesn't includes vimeo iframe" do
-            get '/cndt2020/talks/1'
-            expect(response).to be_successful
-            expect(response.body).to_not include "player.vimeo.com"
-          end
+        it "doesn't includes vimeo iframe" do
+          get '/cndt2020/talks/1'
+          expect(response).to be_successful
+          expect(response.body).to_not include "player.vimeo.com"
         end
       end
 
@@ -113,28 +71,23 @@ describe TalksController, type: :request do
           create(:cndt2020_archived)
         end
 
-        context 'talk is archived' do
-          before do
-            allow_any_instance_of(Talk).to receive(:archived?).and_return(true)
-          end
+        it "includes vimeo iframe" do
+          get '/cndt2020/talks/1'
+          expect(response).to be_successful
+          expect(response.body).to include "player.vimeo.com"
+        end
+      end
 
-          it "includes vimeo iframe" do
-            get '/cndt2020/talks/1'
-            expect(response).to be_successful
-            expect(response.body).to include "player.vimeo.com"
-          end
+      context 'site is video_enabled' do
+        before do
+          Conference.destroy_all
+          create(:cndt2020_video_enabled)
         end
 
-        context 'talk is not archived' do
-          before do
-            allow_any_instance_of(Talk).to receive(:archived?).and_return(false)
-          end
-
-          it "doesn't includes vimeo iframe" do
-            get '/cndt2020/talks/1'
-            expect(response).to be_successful
-            expect(response.body).to_not include "player.vimeo.com"
-          end
+        it "doesn't includes vimeo iframe" do
+          get '/cndt2020/talks/1'
+          expect(response).to be_successful
+          expect(response.body).not_to include "player.vimeo.com"
         end
       end
     end
@@ -168,40 +121,10 @@ describe TalksController, type: :request do
             expect(response.body).to include talk2.title
           end
 
-          it "includes slido iframe if it has slido id" do
+          it "doesn't includes vimeo iframe" do
             get '/cndt2020/talks/1'
             expect(response).to be_successful
-            expect(response.body).to include "sli.do"
-          end
-
-          it "includes twitter iframe if it not have slido id" do
-            get '/cndt2020/talks/2'
-            expect(response).to be_successful
-            expect(response.body).to include "twitter-timeline"
-          end
-
-          context 'talk is archived' do
-            before do
-              allow_any_instance_of(Talk).to receive(:archived?).and_return(true)
-            end
-
-            it "includes vimeo iframe" do
-              get '/cndt2020/talks/1'
-              expect(response).to be_successful
-              expect(response.body).not_to include "player.vimeo.com"
-            end
-          end
-
-          context 'talk is not archived' do
-            before do
-              allow_any_instance_of(Talk).to receive(:archived?).and_return(false)
-            end
-
-            it "includes vimeo iframe" do
-              get '/cndt2020/talks/1'
-              expect(response).to be_successful
-              expect(response.body).not_to include "player.vimeo.com"
-            end
+            expect(response.body).not_to include "player.vimeo.com"
           end
         end
 
@@ -234,28 +157,10 @@ describe TalksController, type: :request do
             expect(response).to have_http_status '404'
           end
 
-          context 'talk is archived' do
-            before do
-              allow_any_instance_of(Talk).to receive(:archived?).and_return(true)
-            end
-
-            it "includes vimeo iframe" do
-              get '/cndt2020/talks/1'
-              expect(response).to be_successful
-              expect(response.body).to include "player.vimeo.com"
-            end
-          end
-
-          context 'talk is not archived' do
-            before do
-              allow_any_instance_of(Talk).to receive(:archived?).and_return(false)
-            end
-
-            it "includes vimeo iframe" do
-              get '/cndt2020/talks/1'
-              expect(response).to be_successful
-              expect(response.body).not_to include "player.vimeo.com"
-            end
+          it "includes vimeo iframe" do
+            get '/cndt2020/talks/1'
+            expect(response).to be_successful
+            expect(response.body).to include "player.vimeo.com"
           end
         end
 
@@ -288,28 +193,10 @@ describe TalksController, type: :request do
             expect(response).to have_http_status '404'
           end
 
-          context 'talk is archived' do
-            before do
-              allow_any_instance_of(Talk).to receive(:archived?).and_return(true)
-            end
-
-            it "includes vimeo iframe" do
-              get '/cndt2020/talks/1'
-              expect(response).to be_successful
-              expect(response.body).to include "player.vimeo.com"
-            end
-          end
-
-          context 'talk is not archived' do
-            before do
-              allow_any_instance_of(Talk).to receive(:archived?).and_return(false)
-            end
-
-            it "includes vimeo iframe" do
-              get '/cndt2020/talks/1'
-              expect(response).to be_successful
-              expect(response.body).not_to include "player.vimeo.com"
-            end
+          it "includes vimeo iframe" do
+            get '/cndt2020/talks/1'
+            expect(response).to be_successful
+            expect(response.body).to include "player.vimeo.com"
           end
         end
 
@@ -342,28 +229,28 @@ describe TalksController, type: :request do
             expect(response).to have_http_status '404'
           end
 
-          context 'talk is archived' do
-            before do
-              allow_any_instance_of(Talk).to receive(:archived?).and_return(true)
-            end
-
-            it "includes vimeo iframe" do
-              get '/cndt2020/talks/1'
-              expect(response).to be_successful
-              expect(response.body).to include "player.vimeo.com"
-            end
+          it "includes vimeo iframe" do
+            get '/cndt2020/talks/1'
+            expect(response).to be_successful
+            expect(response.body).to include "player.vimeo.com"
           end
+        end
 
-          context 'talk is not archived' do
-            before do
-              allow_any_instance_of(Talk).to receive(:archived?).and_return(false)
-            end
-
-            it "includes vimeo iframe" do
-              get '/cndt2020/talks/1'
-              expect(response).to be_successful
-              expect(response.body).not_to include "player.vimeo.com"
-            end
+        context 'site is video_enabled' do
+          before do
+            Conference.destroy_all
+            create(:cndt2020_video_enabled)
+            create(:cndo2021)
+            create(:alice)
+            create(:alice_cndo2021)
+            allow_any_instance_of(ActionDispatch::Request).to receive(:session).and_return(session)
+            allow_any_instance_of(Talk).to receive(:archived?).and_return(true)
+          end
+  
+          it "includes vimeo iframe" do
+            get '/cndt2020/talks/1'
+            expect(response).to be_successful
+            expect(response.body).to include "player.vimeo.com"
           end
         end
       end


### PR DESCRIPTION
Fix #55 

7.14に向けたビデオ公開モードを実装。

video_enabled status
- openに近い
- が、ダッシュボードから視聴画面にリダイレクトはされない

というモード。

Permalinkで視聴画面を広く保つためにtwitter表示機能と、使われていないslido表示機能を消した