### PR TITLE
Refine dashboard and talks

### DIFF
--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -12,6 +12,7 @@ class TalksController < ApplicationController
   def show
     @conference = Conference.find_by(abbr: event_name)
     @talk = Talk.find_by(id: params[:id], conference_id: conference.id)
+    @booths = Booth.where(conference_id: @conference.id, published: true)
     raise ActiveRecord::RecordNotFound unless @talk
   end
 

--- a/app/controllers/tracks_controller.rb
+++ b/app/controllers/tracks_controller.rb
@@ -3,7 +3,11 @@ class TracksController < ApplicationController
   before_action :set_profile
 
   def index
-    @conference = Conference.includes(:talks).find_by(abbr: event_name)
+    @conference = Conference
+                  .includes(:talks)
+                  .includes(sponsor_types: {sponsors: :sponsor_attachment_logo_image})
+                  .order("sponsor_types.order ASC")
+                  .find_by(abbr: event_name)
     # TODO: cndo2021固有の処理をやめる
     if @conference.abbr == "cndo2021" && @conference.opened?
       redirect_to  '/cndo2021/ui/'

--- a/app/javascript/stylesheets/_global.scss
+++ b/app/javascript/stylesheets/_global.scss
@@ -62,7 +62,6 @@ footer ul li {
 .main-pane .talk {
     background-color: #FFF;
     border-radius: 5px;
-    border: solid 1px #CCC;
     overflow: hidden;
     padding: 10px;
 }

--- a/app/javascript/stylesheets/_tracks.scss
+++ b/app/javascript/stylesheets/_tracks.scss
@@ -109,3 +109,13 @@
     align-items: center;
     justify-content: center;
 }
+
+#logo-carousel {
+    height: 50px;
+    .carousel-inner .carousel-item {
+        img {
+            max-width: 100%;
+            height: 50px;
+        }
+    }
+}

--- a/app/javascript/stylesheets/_tracks.scss
+++ b/app/javascript/stylesheets/_tracks.scss
@@ -6,15 +6,9 @@
     margin: 30px 0px 0px 0px;
 }
 
-#main-pane {
-    padding-top: 10px;
-}
-
 #sub-pane {
     padding-top: 10px;
 }
-
-.movie-wrap {}
 
 .tool-pane .nav-item {
     background-color: white;
@@ -36,77 +30,77 @@
     padding: 10px;
 }
 
-#main-pane .talk {
-    // background-color: #FFF;
-    // border-radius: 5px;
-    // border: solid 1px #CCC;
-    // overflow: hidden;
-    //padding: 10px;
-}
-
-#main-pane h3 {
-    margin: 0 0 0.7rem 0;
-    font-size: x-large;
-    color: #333;
-    font-weight: bold;
-}
-
-#main-pane h4 {
-    margin: 0 0 0.7rem 0;
-    font-size: large;
-    color: #333;
-    font-weight: bold;
-}
-
-#main-pane h5 {
-    margin: 0 0 0.7rem 0;
-    font-size: 0.9rem;
-    color: #333;
-    font-weight: bold;
-}
-
-#main-pane .talk .category_difficulty.one-liner {
-    margin: 0 0 0.2rem 0rem;
-    font-size: small;
-}
-
-#main-pane .talk .category_difficulty.block {
-    margin: 0 0 1rem 0rem;
-    font-size: medium;
-}
-
-#main-pane .talk .difficulty {
-    font-size: x-small;
-    padding: 0.2rem;
-    margin: 0;
-    color: #FFF;
-    background: $dark-blue;
-    border-radius: 10px;
+#main-pane {
+    padding-top: 10px;
+    h3 {
+        margin: 0 0 0.7rem 0;
+        font-size: x-large;
+        color: #333;
+        font-weight: bold;
+    }
+    h4 {
+        margin: 0 0 0.7rem 0;
+        font-size: large;
+        color: #333;
+        font-weight: bold;
+    }
+    h5 {
+        margin: 0 0 0.7rem 0;
+        font-size: 0.9rem;
+        color: #333;
+        font-weight: bold;
+    }
+    .talk .category_difficulty.one-liner {
+        margin: 0 0 0.2rem 0rem;
+        font-size: small;
+    }
+    .talk .category_difficulty.block {
+        margin: 0 0 1rem 0rem;
+        font-size: medium;
+    }
+    .talk .difficulty {
+        font-size: x-small;
+        padding: 0.2rem;
+        margin: 0;
+        color: #FFF;
+        background: $dark-blue;
+        border-radius: 10px;
+    }
 }
 
 #registered-talk {
     background-color: #FFF;
-}
-
-#registered-talk button {
-    background-color: #FFF;
-}
-
-#registered-talk button[aria-expanded="true"]:before {
-    content: "▼";
-}
-
-#registered-talk button[aria-expanded="false"]:before {
-    content: "▶";
+    button {
+        background-color: #FFF;
+    }
+    button[aria-expanded="true"]:before {
+        content: "▼";
+    }
+    button[aria-expanded="false"]:before {
+        content: "▶";
+    }
 }
 
 #registered-talk-list {
     padding-left: 10px;
+    .card-column {
+        position: relative;
+    }
+    .registered-talk-card {
+        width: 100%;
+        height: 100%;
+    }
+    .registered-talk-card:hover {
+        background-color: $primary;
+        opacity: 0.8;
+    }
+    .avatar {
+        text-align: center;
+        img {
+            margin: 10px auto 0 auto;
+        }
+    }
 }
-
-#track_information {}
-
-#social {}
 
 #social a {
     display: flex;

--- a/app/views/booths/index.html.erb
+++ b/app/views/booths/index.html.erb
@@ -1,7 +1,7 @@
 <div class="container">
   <h1 class="my-3 text-center">ブース</h1>
   <div class="row">
-    <% if @conference.opened? %>
+    <% if @conference.opened? || @conference.video_enabled? %>
       <% @booths.each do |booth| %>
         <div class="col-12 col-md-4 my-3 text-center">
           <% if booth.published && booth.sponsor.sponsor_attachment_logo_image.present? %>

--- a/app/views/layouts/_event_header.html.erb
+++ b/app/views/layouts/_event_header.html.erb
@@ -21,7 +21,7 @@
           <% end %>
           <% unless controller_name == "profiles" && (action_name == "new" || action_name == "create") %>
             <% if @conference.present? && (@conference.opened? || @conference.video_enabled?) %>
-              <li class="nav-item"><%= link_to "Booths", booths_path, class: "nav-link js-scroll-trigger" %></li>
+              <li class="nav-item"><%= link_to "ブース", booths_path, class: "nav-link js-scroll-trigger" %></li>
             <% end %>
 
             <li class="nav-item dropdown">

--- a/app/views/talks/partial_show/_col_main_pane.html.erb
+++ b/app/views/talks/partial_show/_col_main_pane.html.erb
@@ -1,16 +1,14 @@
 <div class="row">
   <div class="col-12">
     <div class="talk">
-
+      <div class="row">
+        <%= render 'talks/partial_show/col_talk_category_block', talk: talk %>
+      </div>
       <h3>
         <%= talk.title %>
         <%= render 'talks/partial_show/twitter_share_button', hash_tag: conference.abbr.upcase %>
         <%= render 'talks/partial_show/facebook_share_button', url: request.original_url %>
       </h3>
-
-      <div class="row py-3">
-        <%= render 'talks/partial_show/col_talk_category_block', talk: talk %>
-      </div>
 
       <% if (conference.closed? && @current_user) || (conference.opened? && @current_user) || (conference.video_enabled? && @current_user) ||  conference.archived? %>
         <%= render 'talks/partial_show/talk_video_block', talk: talk %>
@@ -34,7 +32,7 @@
       <% end %>
 
       <div class="col-12 text-center my-4">
-        <%= button_to '.セッション一覧', timetables_path, {method: :get, class: "btn btn-primary btn-xl inline" } %>
+        <%= button_to 'セッション一覧', timetables_path, {method: :get, class: "btn btn-primary btn-xl inline" } %>
       </div>
     </div>
   </div>

--- a/app/views/talks/show.html.erb
+++ b/app/views/talks/show.html.erb
@@ -19,16 +19,11 @@
   </div>
   <div class="row my-3">
     <% if @current_user && (@conference.opened? || @conference.video_enabled?) %>
-        <div class="col-12 mb-3">
-          <h4>ブース</h4>
-          <%= render 'tracks/booth_section' %>
-        </div>
-      <% else %>
-        <div class="col-12">
-          <h4 class="text-center booths-header"><%= @conference.name %> is not opened.</h4>
-        </div>
-      <% end %>
-    </div>
+      <div class="col-12 mb-3">
+        <h4>ブース</h4>
+        <%= render 'tracks/booth_section' %>
+      </div>
+    <% end %>
   </div>
 </div>
 

--- a/app/views/talks/show.html.erb
+++ b/app/views/talks/show.html.erb
@@ -9,13 +9,26 @@
 <% end %>
 <% provide(:title, @talk.title) %>
 
-<div class="container">
+<div class="container tracks">
   <div class="row my-3">
 
     <div class="col-12 main-pane">
       <%= render 'talks/partial_show/col_main_pane', talk: @talk, conference: @conference %>
     </div>
 
+  </div>
+  <div class="row my-3">
+    <% if @current_user && (@conference.opened? || @conference.video_enabled?) %>
+        <div class="col-12 mb-3">
+          <h4>ブース</h4>
+          <%= render 'tracks/booth_section' %>
+        </div>
+      <% else %>
+        <div class="col-12">
+          <h4 class="text-center booths-header"><%= @conference.name %> is not opened.</h4>
+        </div>
+      <% end %>
+    </div>
   </div>
 </div>
 

--- a/app/views/tracks/_booth_section.html.erb
+++ b/app/views/tracks/_booth_section.html.erb
@@ -1,7 +1,7 @@
 <div class="container">
   <div class="row">
     <% @booths.shuffle.each do |booth| %>
-      <div class="col-12 col-sm-4 my-3 text-center">
+      <div class="col-12 col-lg-3 col-md-4 my-3 text-center">
         <div class="booth-frame">
           <% if booth.published && booth.sponsor.sponsor_attachment_logo_image.present? %>
             <%= link_to booth_path(id: booth.id) do %>

--- a/app/views/tracks/waiting.html.erb
+++ b/app/views/tracks/waiting.html.erb
@@ -13,6 +13,26 @@
         </ul>
       </div>
 
+      <div id="logo-carousel" class="carousel slide my-5" data-ride="carousel">
+        <div class="carousel-inner">
+          <% count = 1%>
+          <% @conference.sponsors.each_slice(3) do |sponsor_chunk| %>
+            <div class="carousel-item <%= "active" if count == 1 %>">
+              <div class="row">
+                <% sponsor_chunk.each do |sponsor| %>
+                  <% if sponsor.sponsor_attachment_logo_image.present? %>
+                    <div class="col-0 col-lg-4">
+                      <%= image_tag sponsor.sponsor_attachment_logo_image.url, class: "sponsor-logo" %>
+                    </div>
+                  <% end %>
+                <% end %>
+              </div>
+            </div>
+            <% count = count + 1 %>
+          <% end %>
+        </div>
+      </div>
+
       <div id="registered-talk" class="talk accordion mt-3">
         <h4 class="">
           <% if @conference.opened? || @conference.video_enabled? %>

--- a/app/views/tracks/waiting.html.erb
+++ b/app/views/tracks/waiting.html.erb
@@ -1,6 +1,6 @@
 <div class="container tracks">
   <div class="row">
-    <div id="main-pane" class="col-12 col-md-8">
+    <div id="main-pane" class="col-12">
       <div class="information">
         <h4>運営からのお知らせ</h4>
         <ul>
@@ -13,27 +13,28 @@
         </ul>
       </div>
 
-      <div id="social" class="row">
-        <div class="col-6 p-3">
-          <a id="twitter" href=<%=  "http://twitter.com/share?url=https://cloudopsdays.com/&related=@cloudopsdays&hashtags=#{@conference.abbr.upcase}" %> target="_blank" class="btn btn-outline-primary btn-lg btn-block">Twitterでシェア</a>
-        </div>
-      </div>
-
       <div id="registered-talk" class="talk accordion mt-3">
         <h4 class="">
+          <% if @conference.opened? || @conference.video_enabled? %>
+            聴講セッション(クリックで再生ページへ)
+          <% else %>
             聴講予定セッション
+          <% end%>
         </h4>
-        <div id="registered-talk-list">
+        <div id="registered-talk-list" class="row">
           <% @profile.talks.each do |talk| %>
-            <div class="category_difficulty">
-              <% if talk.talk_difficulty.present? && talk.talk_difficulty_id != 4 && talk.talk_category_id != 18 %>
-                <span class="difficulty difficulty_<%= talk_difficulty(talk).id %>"><%= talk_difficulty(talk).name %></span>
-              <% end %>
-              <% if talk.talk_category_id %>
-              <span class="difficulty category_<%= talk_category(talk).id %>"><%= talk_category(talk).name %></span>
-              <% end %>
+            <div class="col-12 col-lg-3 col-md-4 card-column py-3">
+              <a href="<%= talk_path(id: talk.id) %>">
+              <div class="card registered-talk-card">
+                <div class="avatar">
+                  <%= image_tag talk.speakers[0].avatar_or_dummy_url, :size => '90x90' %>
+                </div>
+                <div class="card-body">
+                  <h5><%= talk.title %></h5>
+                </div>
+              </div>
+              </a>
             </div>
-            <h5><%= link_to talk.title, talk_path(id: talk.id), class: "text-dark" %></h5>
           <% end %>
           <div class="col-12 text-center my-4">
               <%= button_to '聴講予定セッションを変更する', timetables_path, {method: :get, class: "btn btn-primary btn-xl inline" } %>
@@ -41,20 +42,12 @@
         </div>
       </div>
     </div>
-    <div id="sub-pane" class="col-12 col-md-4">
-      <div class="social">
-        <a class="twitter-timeline" data-height="600" href="https://twitter.com/cloudopsdays?ref_src=twsrc%5Etfw">Tweets by cloudopsdays</a> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-      </div>
-    </div>
   </div>
 
   <div class="row">
-    <% if @conference.opened? %>
-      <div class="col-12 mb-3 py-1 my-3 text-center booths-header">
-        <h4>↓ ブースにお立ち寄りください ↓</h4>
-      </div>
-
+    <% if @conference.opened? || @conference.video_enabled? %>
       <div class="col-12 mb-3">
+        <h4>ブース</h4>
         <%= render 'booth_section' %>
       </div>
     <% else %>
@@ -63,10 +56,8 @@
       </div>
     <% end %>
   </div>
-
 </div>
-<script>
-</script>
+
 
 <% @message_box = "セッション一覧から聴講予定セッションの登録・変更ができます。" %>
 <%= javascript_pack_tag 'tracks/waiting_channel.js' %>


### PR DESCRIPTION
Fix #53 

Dashboardの聴講セッション一覧の見栄えを変えた。ロゴのカルーセルも実装
![image](https://user-images.githubusercontent.com/79102/125191528-e4a8f700-e27d-11eb-8f48-429389d46242.png)

Dashboardの下にブースが出る(CNDT2020の機能を流用)
![image](https://user-images.githubusercontent.com/79102/125191539-ed99c880-e27d-11eb-8a0c-b1ba9b25c42e.png)

各セッションの下にもブースが出る
![image](https://user-images.githubusercontent.com/79102/125191549-fb4f4e00-e27d-11eb-930c-d41e82785cce.png)
