### PR TITLE
TalkにSpeakerが紐付いていないときのエラーを修正

### DIFF
--- a/app/views/tracks/waiting.html.erb
+++ b/app/views/tracks/waiting.html.erb
@@ -58,7 +58,9 @@
               <a href="<%= talk_path(id: talk.id) %>">
               <div class="card registered-talk-card">
                 <div class="avatar">
-                  <%= image_tag talk.speakers[0].avatar_or_dummy_url, :size => '90x90' %>
+                  <% unless talk.speakers[0].blank? %>
+                    <%= image_tag talk.speakers[0].avatar_or_dummy_url, :size => '90x90' %>
+                  <% end %>
                 </div>
                 <div class="card-body">
                   <h5><%= talk.title %></h5>


### PR DESCRIPTION
Fix #84

Review appsでエラーが出るという内容だったが、実際にはログインフローの問題ではなく、セッションにユーザーが紐付いていない場合に出るエラーだった。

本番のデータでは全てのセッションに登壇者が紐付いているので発生していなかったが、将来的にそういうデータが入らないとも限らないので、直しておく